### PR TITLE
[2024/06/05] feat/user-read >> 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -52,6 +52,7 @@ public class UserController {
 
     @GetMapping("/user/me")
     public ResponseEntity<UserProfileDto> getCurrentUserProfile(Authentication authentication) {
+        // 인증 객체에서 사용자 정보를 추출
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
         UserProfileDto userProfile = userService.getUserProfile(userDetails.getUser().getId());
         return ResponseEntity.ok(userProfile);

--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -2,14 +2,18 @@ package com.sparta.igeomubwotna.controller;
 
 import com.sparta.igeomubwotna.dto.Response;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
+import com.sparta.igeomubwotna.dto.UserProfileDto;
+import com.sparta.igeomubwotna.security.UserDetailsImpl;
 import com.sparta.igeomubwotna.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +48,12 @@ public class UserController {
 
         // UserService의 signup 메서드에 데이터 넘겨 줌
         return userService.signup(requestDto);
+    }
+
+    @GetMapping("/user/me")
+    public ResponseEntity<UserProfileDto> getCurrentUserProfile(Authentication authentication) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        UserProfileDto userProfile = userService.getUserProfile(userDetails.getUser().getId());
+        return ResponseEntity.ok(userProfile);
     }
 }

--- a/src/main/java/com/sparta/igeomubwotna/dto/UserProfileDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/UserProfileDto.java
@@ -1,0 +1,20 @@
+package com.sparta.igeomubwotna.dto;
+
+import com.sparta.igeomubwotna.entity.User;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileDto {
+	private String userId;
+	private String name;
+	private String description;
+	private String email;
+
+	public UserProfileDto(User user) {
+		this.userId = user.getUserId();
+		this.name = user.getName();
+		this.description = user.getDescription();
+		this.email = user.getEmail();
+	}
+}

--- a/src/main/java/com/sparta/igeomubwotna/entity/UserStatusEnum.java
+++ b/src/main/java/com/sparta/igeomubwotna/entity/UserStatusEnum.java
@@ -1,8 +1,8 @@
 package com.sparta.igeomubwotna.entity;
 
 public enum UserStatusEnum {
-	ACTIVE(Status.ACTIVE),  // 정상
-	WITHDRAWN(Status.WITHDRAWN);  // 탈퇴
+	ACTIVE(Authority.ACTIVE),  // 정상
+	WITHDRAWN(Authority.WITHDRAWN);  // 탈퇴
 
 	private final String status;
 
@@ -14,8 +14,8 @@ public enum UserStatusEnum {
 		return this.status;
 	}
 
-	public static class Status {
-		public static final String ACTIVE = "STATUS_ACTIVE";
-		public static final String WITHDRAWN = "STATUS_WITHDRAWN";
+	public static class Authority {
+		public static final String ACTIVE = "ROLE_STATUS_ACTIVE";
+		public static final String WITHDRAWN = "ROLE_STATUS_WITHDRAWN";
 	}
 }

--- a/src/main/java/com/sparta/igeomubwotna/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/igeomubwotna/security/UserDetailsImpl.java
@@ -34,10 +34,14 @@ public class UserDetailsImpl implements UserDetails {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
+		// 사용자 상태를 가져옴
 		UserStatusEnum status = user.getStatus();
+		// 상태를 권한 문자열로 변환
 		String authority = status.getStatus();
 
+		// 권한 문자열을 SimpleGrantedAuthority 객체로 만듦
 		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		// 권한을 저장할 컬렉션을 생성하고 추가
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
 		authorities.add(simpleGrantedAuthority);
 

--- a/src/main/java/com/sparta/igeomubwotna/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/igeomubwotna/security/UserDetailsImpl.java
@@ -1,0 +1,66 @@
+package com.sparta.igeomubwotna.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.sparta.igeomubwotna.entity.User;
+import com.sparta.igeomubwotna.entity.UserStatusEnum;
+
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getName();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserStatusEnum status = user.getStatus();
+		String authority = status.getStatus();
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -2,6 +2,7 @@ package com.sparta.igeomubwotna.service;
 
 import com.sparta.igeomubwotna.dto.Response;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
+import com.sparta.igeomubwotna.dto.UserProfileDto;
 import com.sparta.igeomubwotna.entity.User;
 import com.sparta.igeomubwotna.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -48,5 +51,12 @@ public class UserService {
         // 성공 메시지와 상태 코드 반환
         Response response = new Response(HttpStatus.OK.value(), "회원가입에 성공하였습니다.");
         return ResponseEntity.ok(response);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileDto getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 사용자의 프로필을 찾을 수 없습니다."));
+        return new UserProfileDto(user);
     }
 }

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -55,6 +55,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserProfileDto getUserProfile(Long userId) {
+        // ID로 사용자를 검색하고, 없으면 예외를 던짐
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 사용자의 프로필을 찾을 수 없습니다."));
         return new UserProfileDto(user);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 #14 #15 

## 📝작업 내용

> - UserDetails 인터페이스의 구현체인 UserDetailsImpl 생성
> - 프로필 조회 시 반환할 정보를 담는  UserProfileDto 생성
> -  회원 프로필 조회 코드 구현 (UserController, UserService)

1.  클라이언트가 /user/me 경로로 GET 요청을 보냄.
2. 디스패처 서블릿이 요청을 컨트롤러의 getCurrentUserProfile 메서드에 매핑.
3. Authentication 객체를 통해 현재 인증된 사용자의 정보를 가져옴.
4. UserDetailsImpl 객체에서 사용자 ID를 추출.
5. 서비스 레이어(UserService)에 사용자 ID를 전달하여 프로필 정보를 요청.
6. UserProfileDto 객체를 포함하는 ResponseEntity를 생성하여 반환.
7. 클라이언트는 사용자 프로필 정보를 포함한 HTTP 응답을 받음.

