### PR TITLE
[2024/06/05] feat/sign-in >> 로그인 기능 구현 (리프레시 토큰 x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ repositories {
 }
 
 dependencies {
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -25,10 +25,8 @@ public class UserController {
     }
 
     @PostMapping("/user/login")
-    public ResponseEntity<Response> signin(@RequestBody @Valid SigninRequestDto requestDto, HttpServletResponse response, BindingResult bindingResult) {
-        userService.signin(requestDto, response, bindingResult);
-
-        return null;
+    public ResponseEntity<Response> signin(@RequestBody @Valid SigninRequestDto requestDto, HttpServletResponse res, BindingResult bindingResult) {
+        return userService.signin(requestDto, res, bindingResult);
     }
 
 }

--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -4,21 +4,15 @@ import com.sparta.igeomubwotna.dto.Response;
 import com.sparta.igeomubwotna.dto.SigninRequestDto;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
-
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserController {
@@ -26,45 +20,15 @@ public class UserController {
 
     @PostMapping("/user/signup")
     public ResponseEntity<Response> signup(@RequestBody @Valid SignupRequestDto requestDto, BindingResult bindingResult) {
-        ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
-
-        if (returnError != null) {
-            return returnError;
-        }
-
         // UserService의 signup 메서드에 데이터 넘겨 줌
-        return userService.signup(requestDto);
+        return userService.signup(requestDto, bindingResult);
     }
 
     @PostMapping("/user/login")
-    public ResponseEntity<Response> signin(@RequestBody @Valid SigninRequestDto requestDto, BindingResult bindingResult) {
-        ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
-
-        if (returnError != null) {
-            return returnError;
-        }
-        return null;
-    }
-
-    // 클라이언트에서 입력받아 오는 값을 유효성 검사하는 로직
-    public ResponseEntity<Response> checkError(String message, BindingResult bindingResult) {
-        // 유효성 검사 예외 처리
-        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
-
-        // 유효성 검사에 오류가 있으면
-        if (fieldErrors.size() > 0) {
-            // 모든 필드 오류에 대해 로그 기록 및 오류 메시지 수집
-            List<String> errorMessages = new ArrayList<>();
-            for (FieldError fieldError : bindingResult.getFieldErrors()) {
-                String errorMessage = fieldError.getField() + " 필드: " + fieldError.getDefaultMessage();
-                log.error(errorMessage);
-                errorMessages.add(errorMessage);
-            }
-            // 오류 메시지와 상태 코드 반환
-            Response response = new Response(HttpStatus.BAD_REQUEST.value(), message, errorMessages);
-            return ResponseEntity.badRequest().body(response);
-        }
+    public ResponseEntity<Response> signin(@RequestBody @Valid SigninRequestDto requestDto, HttpServletResponse response, BindingResult bindingResult) {
+        userService.signin(requestDto, response, bindingResult);
 
         return null;
     }
+
 }

--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sparta.igeomubwotna.controller;
 
 import com.sparta.igeomubwotna.dto.Response;
+import com.sparta.igeomubwotna.dto.SigninRequestDto;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.service.UserService;
 import jakarta.validation.Valid;
@@ -25,6 +26,28 @@ public class UserController {
 
     @PostMapping("/user/signup")
     public ResponseEntity<Response> signup(@RequestBody @Valid SignupRequestDto requestDto, BindingResult bindingResult) {
+        ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
+
+        if (returnError != null) {
+            return returnError;
+        }
+
+        // UserService의 signup 메서드에 데이터 넘겨 줌
+        return userService.signup(requestDto);
+    }
+
+    @PostMapping("/user/login")
+    public ResponseEntity<Response> signin(@RequestBody @Valid SigninRequestDto requestDto, BindingResult bindingResult) {
+        ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
+
+        if (returnError != null) {
+            return returnError;
+        }
+        return null;
+    }
+
+    // 클라이언트에서 입력받아 오는 값을 유효성 검사하는 로직
+    public ResponseEntity<Response> checkError(String message, BindingResult bindingResult) {
         // 유효성 검사 예외 처리
         List<FieldError> fieldErrors = bindingResult.getFieldErrors();
 
@@ -38,11 +61,10 @@ public class UserController {
                 errorMessages.add(errorMessage);
             }
             // 오류 메시지와 상태 코드 반환
-            Response response = new Response(HttpStatus.BAD_REQUEST.value(), "회원가입에 실패하였습니다.", errorMessages);
+            Response response = new Response(HttpStatus.BAD_REQUEST.value(), message, errorMessages);
             return ResponseEntity.badRequest().body(response);
         }
 
-        // UserService의 signup 메서드에 데이터 넘겨 줌
-        return userService.signup(requestDto);
+        return null;
     }
 }

--- a/src/main/java/com/sparta/igeomubwotna/dto/Response.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/Response.java
@@ -1,5 +1,6 @@
 package com.sparta.igeomubwotna.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 import java.util.List;
@@ -7,11 +8,13 @@ import java.util.List;
 public class Response {
     private int statusCode;
     private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값일 경우 직렬화에서 제외
     private List<String> errors;  // 필드 오류 메시지를 담을 리스트
 
     public Response(int statusCode, String message) {
         this.statusCode = statusCode;
         this.message = message;
+        this.errors = null; // 성공 시 errors 필드는 null로 설정
     }
 
     public Response(int statusCode, String message, List<String> errors) {

--- a/src/main/java/com/sparta/igeomubwotna/dto/SigninRequestDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/SigninRequestDto.java
@@ -1,0 +1,6 @@
+package com.sparta.igeomubwotna.dto;
+
+public class SigninRequestDto {
+    private String userId;
+    private String password;
+}

--- a/src/main/java/com/sparta/igeomubwotna/dto/SigninRequestDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/SigninRequestDto.java
@@ -1,6 +1,13 @@
 package com.sparta.igeomubwotna.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+@Getter
+@Setter
 public class SigninRequestDto {
+    @NotBlank(message = "아이디는 공백일 수 없습니다.")
     private String userId;
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
     private String password;
 }

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -1,0 +1,13 @@
+package com.sparta.igeomubwotna.jwt;
+
+public class JwtUtil {
+    // JWT 생성
+
+    // 생성된 JWT를 Cookie에 저장
+
+    // Cookie에 들어있던 JWT 토큰을 Substring
+
+    // JWT 검증
+
+    // JWT에서 사용자 정보 가져오기
+}

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -1,13 +1,60 @@
 package com.sparta.igeomubwotna.jwt;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JWT 관련 로그")
+@Component
 public class JwtUtil {
+    // Header KEY 값 (이름)
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // 사용자 상태 값의 KEY (이름)
+    public static final String AUTHORIZATION_KEY = "status";
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+    // 토큰 만료시간
+    private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    // 딱 한 번만 받아오면 되는 값을 사용할 때마다 요청을 새로고침하는 오류를 방지하기 위해
+    @PostConstruct
+    public void init() {
+        // Base64로 디코딩
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
     // JWT 생성
+    // TODO: 나중에 user에 상태가 필요하면 말씀해 주세요!
+    public String creatToken(String userId) {
+        Date date = new Date();
 
-    // 생성된 JWT를 Cookie에 저장
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId) // 유저 식별 값
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+//                        .claim() // 상태
+    }
 
-    // Cookie에 들어있던 JWT 토큰을 Substring
+    // JWT Cookie에 저장
 
-    // JWT 검증
 
-    // JWT에서 사용자 정보 가져오기
 }

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -1,15 +1,17 @@
 package com.sparta.igeomubwotna.jwt;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
@@ -39,7 +41,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    // JWT 생성
+    // 토큰 생성
     // TODO: 나중에 user에 상태가 필요하면 말씀해 주세요!
     public String creatToken(String userId) {
         Date date = new Date();
@@ -68,4 +70,25 @@ public class JwtUtil {
         }
     }
 
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
 }

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -43,7 +43,7 @@ public class JwtUtil {
 
     // 토큰 생성
     // TODO: 나중에 user에 상태가 필요하면 말씀해 주세요!
-    public String creatToken(String userId) {
+    public String createToken(String userId) {
         Date date = new Date();
 
         return BEARER_PREFIX +

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -70,6 +70,15 @@ public class JwtUtil {
         }
     }
 
+    // JWT 토큰 substring
+    public String substringToken(String tokenValue) {
+        if(StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        log.error("Not Found Token");
+        throw new NullPointerException("Npt Found Token");
+    }
+
     // 토큰 검증
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -55,6 +55,17 @@ public class JwtUtil {
     }
 
     // JWT Cookie에 저장
+    public void addJwtToCookie(String token, HttpServletResponse res) {
+        try {
+            token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20"); // Cokkie애는 공백 불가 -> %20로 변경
 
+            Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // 이름 값
+            cookie.setPath("/");
+
+            res.addCookie(cookie);
+        } catch (UnsupportedEncodingException e) {
+            log.error(e.getMessage());
+        }
+    }
 
 }

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -1,24 +1,38 @@
 package com.sparta.igeomubwotna.service;
 
 import com.sparta.igeomubwotna.dto.Response;
+import com.sparta.igeomubwotna.dto.SigninRequestDto;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.entity.User;
 import com.sparta.igeomubwotna.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public ResponseEntity<Response> signup(SignupRequestDto requestDto) {
+    public ResponseEntity<Response> signup(SignupRequestDto requestDto, BindingResult bindingResult) {
+        ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
+
+        if (returnError != null) {
+            return returnError;
+        }
+
         String userId = requestDto.getUserId();
         String password = passwordEncoder.encode(requestDto.getPassword());
 
@@ -48,5 +62,26 @@ public class UserService {
         // 성공 메시지와 상태 코드 반환
         Response response = new Response(HttpStatus.OK.value(), "회원가입에 성공하였습니다.");
         return ResponseEntity.ok(response);
+    }
+    // 클라이언트에서 입력받아 오는 값을 유효성 검사하는 로직
+    public ResponseEntity<Response> checkError(String message, BindingResult bindingResult) {
+        // 유효성 검사 예외 처리
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+
+        // 유효성 검사에 오류가 있으면
+        if (fieldErrors.size() > 0) {
+            // 모든 필드 오류에 대해 로그 기록 및 오류 메시지 수집
+            List<String> errorMessages = new ArrayList<>();
+            for (FieldError fieldError : bindingResult.getFieldErrors()) {
+                String errorMessage = fieldError.getField() + " 필드: " + fieldError.getDefaultMessage();
+                log.error(errorMessage);
+                errorMessages.add(errorMessage);
+            }
+            // 오류 메시지와 상태 코드 반환
+            Response response = new Response(HttpStatus.BAD_REQUEST.value(), message, errorMessages);
+            return ResponseEntity.badRequest().body(response);
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -90,7 +90,7 @@ public class UserService {
             }
 
             // TODO: JWT 생성 및 쿠키에 저장 후 Response 객체에 추가
-            String token = jwtUtil.creatToken(userId); // 토큰 생성
+            String token = jwtUtil.createToken(userId); // 토큰 생성
             jwtUtil.addJwtToCookie(token, res); // 쿠키 생성 후 토큰 쿠키에 저장
 
         } else {

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -4,7 +4,9 @@ import com.sparta.igeomubwotna.dto.Response;
 import com.sparta.igeomubwotna.dto.SigninRequestDto;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.entity.User;
+import com.sparta.igeomubwotna.jwt.JwtUtil;
 import com.sparta.igeomubwotna.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     public ResponseEntity<Response> signup(SignupRequestDto requestDto, BindingResult bindingResult) {
         ResponseEntity<Response> returnError = checkError("회원가입에 실패하였습니다.", bindingResult);
@@ -88,6 +91,9 @@ public class UserService {
             }
 
             // TODO: JWT 생성 및 쿠키에 저장 후 Response 객체에 추가
+            String token = jwtUtil.creatToken(userId); // 토큰 생성
+            jwtUtil.addJwtToCookie(token, res); // 쿠키 생성 후 토큰 쿠키에 저장
+
         } else {
             // 오류 메시지와 상태 코드 반환
             Response response = new Response(HttpStatus.BAD_REQUEST.value(), "아이디가 존재하지 않습니다.");

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -37,8 +37,8 @@ public class UserService {
         String password = passwordEncoder.encode(requestDto.getPassword());
 
         // 회원 userId 중복 확인
-        Optional<User> checkUsername = userRepository.findByUserId(userId);
-        if (checkUsername.isPresent()) {
+        Optional<User> checkUserId = userRepository.findByUserId(userId);
+        if (checkUserId.isPresent()) {
             // 오류 메시지와 상태 코드 반환
             Response response = new Response(HttpStatus.BAD_REQUEST.value(), "중복된 아이디가 존재합니다.");
 
@@ -63,6 +63,43 @@ public class UserService {
         Response response = new Response(HttpStatus.OK.value(), "회원가입에 성공하였습니다.");
         return ResponseEntity.ok(response);
     }
+
+    public ResponseEntity<Response> signin(@Valid SigninRequestDto requestDto, HttpServletResponse res, BindingResult bindingResult) {
+        ResponseEntity<Response> returnError = checkError("로그인에 실패하였습니다.", bindingResult);
+
+        if (returnError != null) {
+            return returnError;
+        }
+
+        String userId = requestDto.getUserId();
+        String password = requestDto.getPassword();
+
+        // 있는 회원인지 확인
+        Optional<User> user = userRepository.findByUserId(userId);
+
+        if (user.isPresent()) {
+            // 비밀번호 확인(평문, 암호화)
+            // password가 일치하지 않으면
+            if(!passwordEncoder.matches(password, user.get().getPassword())) {
+                // 오류 메시지와 상태 코드 반환
+                Response response = new Response(HttpStatus.BAD_REQUEST.value(), "비밀번호가 다릅니다.");
+
+                return ResponseEntity.badRequest().body(response);
+            }
+
+            // TODO: JWT 생성 및 쿠키에 저장 후 Response 객체에 추가
+        } else {
+            // 오류 메시지와 상태 코드 반환
+            Response response = new Response(HttpStatus.BAD_REQUEST.value(), "아이디가 존재하지 않습니다.");
+
+            return ResponseEntity.badRequest().body(response);
+        }
+
+        Response response = new Response(HttpStatus.OK.value(), "로그인에 성공하였습니다.");
+
+        return ResponseEntity.ok().body(response);
+    }
+
     // 클라이언트에서 입력받아 오는 값을 유효성 검사하는 로직
     public ResponseEntity<Response> checkError(String message, BindingResult bindingResult) {
         // 유효성 검사 예외 처리
@@ -77,8 +114,7 @@ public class UserService {
                 log.error(errorMessage);
                 errorMessages.add(errorMessage);
             }
-            // 오류 메시지와 상태 코드 반환
-            Response response = new Response(HttpStatus.BAD_REQUEST.value(), message, errorMessages);
+            Response response = new Response(HttpStatus.BAD_REQUEST.value(), message);
             return ResponseEntity.badRequest().body(response);
         }
 

--- a/src/main/java/com/sparta/igeomubwotna/service/UserService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/UserService.java
@@ -6,7 +6,6 @@ import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.entity.User;
 import com.sparta.igeomubwotna.jwt.JwtUtil;
 import com.sparta.igeomubwotna.repository.UserRepository;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#12 
close #12 

## 📝 작업 내용
- JwtUtil을 만들고 로그인에 필요한 여러 메서드들을 만들어 놨습니다(검증 포함)
- 쿠키에 토큰이 저장되고 토큰에 로그인 사용자 정보가 잘 저장되는 것을 확인했습니다.
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/71262367/655bd601-6b10-4370-a200-63d4c57f854d)
- 로그인 request를 받아 service에 넘겨주는 메서드 구현
- service에서 사용자를 검증하고 로그인 처리하여 토큰을 발급해주는 로직을 가진 메서드 구현