### PR TITLE
[2024/06/05] feat/user-modify >> 프로필 수정 기능 구현

### DIFF
--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -11,7 +11,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -38,9 +37,8 @@ public class UserController {
     }
 
     @GetMapping("/user/me")
-    public ResponseEntity<UserProfileDto> getCurrentUserProfile(Authentication authentication) {
+    public ResponseEntity<UserProfileDto> getCurrentUserProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 인증 객체에서 사용자 정보를 추출
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
         UserProfileDto userProfile = userService.getUserProfile(userDetails.getUser().getId());
         return ResponseEntity.ok(userProfile);
     }

--- a/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/UserController.java
@@ -4,6 +4,7 @@ import com.sparta.igeomubwotna.dto.Response;
 import com.sparta.igeomubwotna.dto.SigninRequestDto;
 import com.sparta.igeomubwotna.dto.SignupRequestDto;
 import com.sparta.igeomubwotna.dto.UserProfileDto;
+import com.sparta.igeomubwotna.dto.UserUpdateRequestDto;
 import com.sparta.igeomubwotna.security.UserDetailsImpl;
 import com.sparta.igeomubwotna.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,9 +12,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,5 +43,11 @@ public class UserController {
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
         UserProfileDto userProfile = userService.getUserProfile(userDetails.getUser().getId());
         return ResponseEntity.ok(userProfile);
+    }
+
+    @PatchMapping("/user/me")
+    public ResponseEntity<Response> updateUserProfile(@RequestBody @Valid UserUpdateRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 인증 객체에서 사용자 정보를 추출
+        return userService.updateUserProfile(requestDto, userDetails.getUser().getId());
     }
 }

--- a/src/main/java/com/sparta/igeomubwotna/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/UserUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.sparta.igeomubwotna.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserUpdateRequestDto {
+	@NotBlank
+	private String name;
+
+	@NotBlank
+	private String description;
+
+	private String currentPassword;  // 현재 저장되어 있는 비밀번호와 일치할 시에만 새로운 비밀번호로 변경 가능
+
+	@Size(min = 10, message = "password는 최소 10글자 이상이어야 합니다.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_])\\S{10,}$", message = "password는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로만 구성되어야 합니다.")
+	private String newPassword;
+}

--- a/src/main/java/com/sparta/igeomubwotna/entity/User.java
+++ b/src/main/java/com/sparta/igeomubwotna/entity/User.java
@@ -57,4 +57,16 @@ public class User extends Timestamped {
         this.description = description;
         this.status = UserStatusEnum.ACTIVE;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#19 #20 
close #19 close #20 

## 📝작업 내용

> - 프로필 수정 요청 시 수정할 정보를 담는 UserUpdateRequestDto 생성 및 구현
> - 회원 프로필 수정 코드 구현 (UserController, UserService)
> - getCurrentUserProfile 메서드에서 @AuthenticationPrincipal 애너테이션을 사용하도록 프로필 조회 부분 코드 수정

1. 클라이언트가 /user/me 엔드포인트로 PATCH 요청을 보냄.
2. 요청 본문을 UserUpdateRequestDto로 변환하고 유효성 검사 수행.
3. 인증된 사용자의 정보를 @AuthenticationPrincipal로 추출.
4. userService.updateUserProfile 메서드 호출.
5. 사용자 ID로 사용자를 검색하고, 없으면 예외를 던짐.
6. requestDto의 각 필드를 사용자 객체에 업데이트.
7. 비밀번호 변경 요청이 있는 경우, 현재 비밀번호와 새 비밀번호를 검증하고 설정.
8. 변경된 사용자 정보를 저장.
9. 성공 메시지와 함께 ResponseEntity 객체를 클라이언트에게 반환.