### PR TITLE
[2024/06/10] Feat/recipe read >> 레시피 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
@@ -71,11 +71,9 @@ public class RecipeController {
 
 
 	@GetMapping("/")
-	public ResponseEntity<Page<RecipeResponseDto>> getAllRecipe(@RequestParam("page") int page,
-		@RequestParam("size") int size,
+	public ResponseEntity getAllRecipe(@RequestParam("page") int page,
 		@RequestParam("sortBy") String sortBy) {
-		return ResponseEntity.status(HttpStatus.OK).body(recipeService.getAllRecipe(page-1, sortBy));
-
+		return recipeService.getAllRecipe(page-1, sortBy);
 	}
 
 

--- a/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
@@ -2,7 +2,6 @@ package com.sparta.igeomubwotna.controller;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.igeomubwotna.dto.RecipeRequestDto;
 import com.sparta.igeomubwotna.dto.RecipeResponseDto;
-import com.sparta.igeomubwotna.entity.Recipe;
 import com.sparta.igeomubwotna.security.UserDetailsImpl;
 import com.sparta.igeomubwotna.service.RecipeService;
 
@@ -69,12 +67,18 @@ public class RecipeController {
 		return ResponseEntity.status(HttpStatus.OK).body(recipeService.deleteRecipe(recipeId, userDetails.getUser()));
 	}
 
-
 	@GetMapping("/")
 	public ResponseEntity getAllRecipe(@RequestParam("page") int page,
 		@RequestParam(required = false, defaultValue="createdAt", value ="sortBy") String sortBy) {
 		return recipeService.getAllRecipe(page-1, sortBy);
 	}
 
+	// 기간별 검색 - api 중복 안 됨
+	@GetMapping("/date/")
+	public ResponseEntity getDateRecipe(@RequestParam("page") int page,
+		@RequestParam("startdate") String startDate,
+		@RequestParam("enddate") String endDate) {
+		return recipeService.getDateRecipe(page-1, startDate, endDate);
+	}
 
 }

--- a/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.sparta.igeomubwotna.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -67,4 +68,15 @@ public class RecipeController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return ResponseEntity.status(HttpStatus.OK).body(recipeService.deleteRecipe(recipeId, userDetails.getUser()));
 	}
+
+
+	@GetMapping("/")
+	public ResponseEntity<Page<RecipeResponseDto>> getAllRecipe(@RequestParam("page") int page,
+		@RequestParam("size") int size,
+		@RequestParam("sortBy") String sortBy) {
+		return ResponseEntity.status(HttpStatus.OK).body(recipeService.getAllRecipe(page-1, sortBy));
+
+	}
+
+
 }

--- a/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
@@ -72,7 +72,7 @@ public class RecipeController {
 
 	@GetMapping("/")
 	public ResponseEntity getAllRecipe(@RequestParam("page") int page,
-		@RequestParam("sortBy") String sortBy) {
+		@RequestParam(required = false, defaultValue="createdAt", value ="sortBy") String sortBy) {
 		return recipeService.getAllRecipe(page-1, sortBy);
 	}
 

--- a/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
+++ b/src/main/java/com/sparta/igeomubwotna/controller/RecipeController.java
@@ -76,5 +76,12 @@ public class RecipeController {
 		return recipeService.getAllRecipe(page-1, sortBy);
 	}
 
+	// 기간별 검색 - api 중복 안 됨
+	@GetMapping("/date/")
+	public ResponseEntity getDateRecipe(@RequestParam("page") int page,
+		@RequestParam("startdate") String startDate,
+		@RequestParam("enddate") String endDate) {
+		return recipeService.getDateRecipe(page-1, startDate, endDate);
+	}
 
 }

--- a/src/main/java/com/sparta/igeomubwotna/dto/RecipeResponseDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/RecipeResponseDto.java
@@ -11,6 +11,7 @@ public class RecipeResponseDto {
 	String title;
 	String content;
 	String userId;
+	Long recipeLikes;
 	LocalDateTime createdAt;
 	LocalDateTime modifiedAt;
 
@@ -18,6 +19,7 @@ public class RecipeResponseDto {
 		this.title = recipe.getTitle();
 		this.content = recipe.getContent();
 		this.userId = recipe.getUser().getUserId();
+		this.recipeLikes = recipe.getRecipeLikes();
 		this.createdAt = recipe.getCreatedAt();
 		this.modifiedAt = recipe.getModifiedAt();
 	}

--- a/src/main/java/com/sparta/igeomubwotna/dto/RecipeResponseDto.java
+++ b/src/main/java/com/sparta/igeomubwotna/dto/RecipeResponseDto.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 
 import com.sparta.igeomubwotna.entity.Recipe;
 
+import lombok.Getter;
+
+@Getter
 public class RecipeResponseDto {
 	String title;
 	String content;

--- a/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
+++ b/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
@@ -38,7 +38,7 @@ public class Recipe extends Timestamped{
 	private String content;
 
 	@Column
-	private Long recipeLikes;
+	private Long recipeLikes = 0L;
 
 	public Recipe(RecipeRequestDto requestDto, User user) {
 		this.title = requestDto.getTitle();

--- a/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
+++ b/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
@@ -58,7 +58,13 @@ public class Recipe extends Timestamped{
 	}
 
 	public void update(RecipeRequestDto requestDto) {
-		this.title = requestDto.getTitle();
-		this.content = requestDto.getContent();
+
+		if (requestDto.getTitle() != null) {
+			this.title = requestDto.getTitle();
+		}
+		if (requestDto.getContent() != null) {
+			this.content = requestDto.getContent();
+		}
+
 	}
 }

--- a/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
+++ b/src/main/java/com/sparta/igeomubwotna/entity/Recipe.java
@@ -37,7 +37,7 @@ public class Recipe extends Timestamped{
 	@Column(nullable = false)
 	private String content;
 
-	@Column(nullable = false)
+	@Column
 	private Long recipeLikes;
 
 	public Recipe(RecipeRequestDto requestDto, User user) {
@@ -47,6 +47,7 @@ public class Recipe extends Timestamped{
 	}
 
 	public void update(RecipeRequestDto requestDto) {
+		this.title = requestDto.getTitle();
 		this.content = requestDto.getContent();
 	}
 }

--- a/src/main/java/com/sparta/igeomubwotna/repository/RecipeRepository.java
+++ b/src/main/java/com/sparta/igeomubwotna/repository/RecipeRepository.java
@@ -1,9 +1,15 @@
 package com.sparta.igeomubwotna.repository;
 
+import java.time.LocalDateTime;
+
 import com.sparta.igeomubwotna.entity.Recipe;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+	Page<Recipe> findAllByCreatedAtBetween(Pageable pageable, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
@@ -1,6 +1,10 @@
 package com.sparta.igeomubwotna.service;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +29,6 @@ public class RecipeService {
 
 
 	private final RecipeRepository recipeRepository;
-	// private final LikeService likeService;
 
 	@Transactional
 	public RecipeResponseDto saveRecipe(RecipeRequestDto requestDto, User user) {
@@ -35,7 +38,6 @@ public class RecipeService {
 
 	public RecipeResponseDto getRecipe(Long recipeId) {
 		Recipe recipe = findById(recipeId);
-		// recipe.setRecipeLikes(likeService.getLike(recipe));
 		return new RecipeResponseDto(recipe);
 	}
 
@@ -53,6 +55,7 @@ public class RecipeService {
 
 	}
 
+	@Transactional
 	public String deleteRecipe(Long recipeId, User user) {
 		Recipe recipe = findById(recipeId);
 
@@ -71,6 +74,23 @@ public class RecipeService {
 		Pageable pageable = PageRequest.of(page, 10, sort);
 
 		Page<Recipe> recipeList = recipeRepository.findAll(pageable);
+
+		if (recipeList.getTotalElements() == 0) {
+			return ResponseEntity.status(HttpStatus.OK).body("먼저 작성하여 소식을 알려보세요!");
+		}
+
+		return ResponseEntity.status(HttpStatus.OK).body(recipeList.map(RecipeResponseDto::new));
+	}
+
+	public ResponseEntity getDateRecipe(int page, String startDate, String endDate) {
+
+		LocalDateTime startDateTime = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd")).atTime(0, 0, 0);
+		LocalDateTime endDateTime = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyyMMdd")).atTime(23, 59, 59);
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+		Pageable pageable = PageRequest.of(page, 10, sort);
+
+		Page<Recipe> recipeList = recipeRepository.findAllByCreatedAtBetween(pageable, startDateTime, endDateTime);
 
 		if (recipeList.getTotalElements() == 0) {
 			return ResponseEntity.status(HttpStatus.OK).body("먼저 작성하여 소식을 알려보세요!");

--- a/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
@@ -1,6 +1,10 @@
 package com.sparta.igeomubwotna.service;
 
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +42,7 @@ public class RecipeService {
 		Recipe recipe = findById(recipeId);
 
 		// 사용자가 일치하지 않는 경우
-		if (recipe.getUser().getId().equals(user.getId())) {
+		if (!(recipe.getUser().getId().equals(user.getId()))) {
 			throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
 		}
 
@@ -51,13 +55,22 @@ public class RecipeService {
 		Recipe recipe = findById(recipeId);
 
 		// 사용자가 일치하지 않는 경우
-		if (recipe.getUser().getId().equals(user.getId())) {
+		if (!(recipe.getUser().getId().equals(user.getId()))) {
 			throw new IllegalArgumentException("작성자만 삭제할 수 있습니다.");
 		}
 
 		recipeRepository.delete(recipe);
 
 		return (recipeId + " 번 삭제 완료");
+	}
+
+	public Page<RecipeResponseDto> getAllRecipe(int page, String sortBy) {
+		Sort sort = Sort.by(Sort.Direction.DESC, sortBy); // 지금 AscDesc 안 정함, 내가 일단 해야하는 건 최신순 정렬
+		Pageable pageable = PageRequest.of(page, 10, sort);
+
+		Page<Recipe> recipeList = recipeRepository.findAll(pageable);
+
+		return recipeList.map(RecipeResponseDto::new);
 	}
 
 	public Recipe findById(Long recipeId) {

--- a/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
@@ -1,6 +1,10 @@
 package com.sparta.igeomubwotna.service;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -71,6 +75,23 @@ public class RecipeService {
 		Pageable pageable = PageRequest.of(page, 10, sort);
 
 		Page<Recipe> recipeList = recipeRepository.findAll(pageable);
+
+		if (recipeList.getTotalElements() == 0) {
+			return ResponseEntity.status(HttpStatus.OK).body("먼저 작성하여 소식을 알려보세요!");
+		}
+
+		return ResponseEntity.status(HttpStatus.OK).body(recipeList.map(RecipeResponseDto::new));
+	}
+
+	public ResponseEntity getDateRecipe(int page, String startDate, String endDate) {
+
+		LocalDateTime startDateTime = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd")).atTime(0, 0, 0);
+		LocalDateTime endDateTime = LocalDate.parse(endDate, DateTimeFormatter.ofPattern("yyyyMMdd")).atTime(23, 59, 59);
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+		Pageable pageable = PageRequest.of(page, 10, sort);
+
+		Page<Recipe> recipeList = recipeRepository.findAllByCreatedAtBetween(pageable, startDateTime, endDateTime);
 
 		if (recipeList.getTotalElements() == 0) {
 			return ResponseEntity.status(HttpStatus.OK).body("먼저 작성하여 소식을 알려보세요!");

--- a/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
@@ -19,6 +19,7 @@ public class RecipeService {
 
 
 	private final RecipeRepository recipeRepository;
+	private final LikeService likeService;
 
 	@Transactional
 	public RecipeResponseDto saveRecipe(RecipeRequestDto requestDto, User user) {
@@ -28,6 +29,7 @@ public class RecipeService {
 
 	public RecipeResponseDto getRecipe(Long recipeId) {
 		Recipe recipe = findById(recipeId);
+		recipe.setRecipeLikes(likeService.getLike(recipe));
 		return new RecipeResponseDto(recipe);
 	}
 

--- a/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
+++ b/src/main/java/com/sparta/igeomubwotna/service/RecipeService.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +25,7 @@ public class RecipeService {
 
 
 	private final RecipeRepository recipeRepository;
-	private final LikeService likeService;
+	// private final LikeService likeService;
 
 	@Transactional
 	public RecipeResponseDto saveRecipe(RecipeRequestDto requestDto, User user) {
@@ -33,7 +35,7 @@ public class RecipeService {
 
 	public RecipeResponseDto getRecipe(Long recipeId) {
 		Recipe recipe = findById(recipeId);
-		recipe.setRecipeLikes(likeService.getLike(recipe));
+		// recipe.setRecipeLikes(likeService.getLike(recipe));
 		return new RecipeResponseDto(recipe);
 	}
 
@@ -64,13 +66,17 @@ public class RecipeService {
 		return (recipeId + " 번 삭제 완료");
 	}
 
-	public Page<RecipeResponseDto> getAllRecipe(int page, String sortBy) {
-		Sort sort = Sort.by(Sort.Direction.DESC, sortBy); // 지금 AscDesc 안 정함, 내가 일단 해야하는 건 최신순 정렬
+	public ResponseEntity getAllRecipe(int page, String sortBy) {
+		Sort sort = Sort.by(Sort.Direction.DESC, sortBy);
 		Pageable pageable = PageRequest.of(page, 10, sort);
 
 		Page<Recipe> recipeList = recipeRepository.findAll(pageable);
 
-		return recipeList.map(RecipeResponseDto::new);
+		if (recipeList.getTotalElements() == 0) {
+			return ResponseEntity.status(HttpStatus.OK).body("먼저 작성하여 소식을 알려보세요!");
+		}
+
+		return ResponseEntity.status(HttpStatus.OK).body(recipeList.map(RecipeResponseDto::new));
 	}
 
 	public Recipe findById(Long recipeId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 
close #38 

## 📝작업 내용

1. 레시피를 10개씩 페이지네이션하여 생성일자 기준 최신 순(기본), 좋아요 많은 순, 기간별 검색 기능 구현
2. 뉴스피드가 없는 경우 Http Status Code를 200으로 두고 메세지 반환
3. 기존 레시피 CRUD 시 발생하던 오류 해결 (ResponseDto에 @Getter 추가, service에서 if문에 ! 추가)

### 스크린샷 

1-1. 생성일자 기준 최신 순 정렬
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/163665929/80768722-8e7d-4390-b51e-f4c17827e6ee)

1-2. 생성일자 기준 최신 순 정렬 - sortBy param 넣지 않아도 최신 순으로 정렬
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/163665929/f2f98035-24e0-4a00-b69d-06f9da1736b7)



2. 좋아요 많은 순 정렬
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/163665929/29ceb171-0794-4839-b509-1ae35ed16d65)


4. 기간별 검색 정렬
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/163665929/82e63c87-8171-4a7f-af0f-b71103db281a)


5. 뉴스피드가 없는 경우
![image](https://github.com/LeeChangHyeong/igeo-mubwotna/assets/163665929/c89c73c4-0f9f-4e98-8894-1ca0c43e3502)


