### PR TITLE
[2024/06/10] feat/sign-in >> 리프레시 토큰 오류 수정

### DIFF
--- a/src/main/java/com/sparta/igeomubwotna/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/igeomubwotna/filter/JwtAuthenticationFilter.java
@@ -57,18 +57,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = jwtUtil.createAccessToken(userId);
         // 응답 헤더에 AccessToken 추가
         response.addHeader(JwtUtil.ACCESS_HEADER, accessToken);
+        // 응답 헤더에 userId 추가
+        response.addHeader(JwtUtil.ACCESS_USERID, userId);
 
         // RefreshToken 생성
         String refreshToken = jwtUtil.createRefreshToken(userId);
 
         // 로그인시 RefreshToken을 user DB에 저장
-        userRepository.findByUserId(userId).ifPresent(
-                user -> {
-                    user.setRefreshToken(refreshToken);
-                    userRepository.save(user);
-                }
-        );
-
         userRepository.findByUserId(userId).ifPresent(
                 user -> {
                     user.setRefreshToken(refreshToken);

--- a/src/main/java/com/sparta/igeomubwotna/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/igeomubwotna/filter/JwtAuthorizationFilter.java
@@ -44,7 +44,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         // HTTP 요청에서 Access 토큰 추출
         String accessToken = jwtUtil.getAccessTokenFromHeader(req);
-        String userId = jwtUtil.getUserInfoFromToken(accessToken).getSubject();
+
+        // HTTP 요청에서 UserId 추출
+        String userId = jwtUtil.getUserIdFromHeader(req);
+
         // 유저 정보로 refreshToken 들고오기
         String refreshToken = userRepository.findByUserId(userId).get().getRefreshToken();
 

--- a/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/igeomubwotna/jwt/JwtUtil.java
@@ -20,8 +20,8 @@ public class JwtUtil {
     // AccessToken KEY 값 (이름)
     public static final String ACCESS_HEADER = "Authorization";
 
-    // 사용자 상태 값의 KEY (이름)
-    public static final String AUTHORIZATION_KEY = "status";
+    // 사용자 아이디 값의 KEY (이름)
+    public static final String ACCESS_USERID = "X-User-Id";
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
     // 토큰 만료시간
@@ -74,6 +74,16 @@ public class JwtUtil {
         String accessToken = request.getHeader(ACCESS_HEADER);
         if (StringUtils.hasText(accessToken) && accessToken.startsWith(BEARER_PREFIX)) {
             return accessToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    // UserId를 header에서 가져와서 반환하는 메서드
+    public String getUserIdFromHeader(HttpServletRequest request) {
+        String userId = request.getHeader(ACCESS_USERID);
+
+        if(StringUtils.hasText(userId)) {
+            return userId;
         }
         return null;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#55 
close #55 

## 📝작업 내용
- 응답 헤더에 유저 아이디 추가
- 유저 아이디를 헤더에서 반환하는 메서드 구현, 사용자 아이디 값 이름 변경
- 헤더에서 유저 아이디 찾아와 refreshToken을 찾도록 변경
